### PR TITLE
Enable Windows Forms high DPI features

### DIFF
--- a/NoFences/App.config
+++ b/NoFences/App.config
@@ -3,4 +3,7 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
+    <System.Windows.Forms.ApplicationConfigurationSection>
+        <add key="DpiAwareness" value="PerMonitorV2" />
+    </System.Windows.Forms.ApplicationConfigurationSection>
 </configuration>

--- a/NoFences/FenceWindow.cs
+++ b/NoFences/FenceWindow.cs
@@ -12,6 +12,7 @@ namespace NoFences
 {
     public partial class FenceWindow : Form
     {
+        private int logicalTitleHeight;
         private int titleHeight;
         private const int titleOffset = 3;
         private const int itemWidth = 75;
@@ -47,7 +48,7 @@ namespace NoFences
         private void ReloadFonts()
         {
             var family = new FontFamily("Segoe UI");
-            titleFont = new Font(family, (int)Math.Floor(titleHeight / 2.0));
+            titleFont = new Font(family, (int)Math.Floor(logicalTitleHeight / 2.0));
             iconFont = new Font(family, 9);
         }
 
@@ -59,11 +60,11 @@ namespace NoFences
             WindowUtil.HideFromAltTab(Handle);
             DesktopUtil.GlueToDesktop(Handle);
             //DesktopUtil.PreventMinimize(Handle);
-            this.titleHeight = fenceInfo.TitleHeight;
+            logicalTitleHeight = (fenceInfo.TitleHeight < 16 || fenceInfo.TitleHeight > 100) ? 35 : fenceInfo.TitleHeight;
+            titleHeight = LogicalToDeviceUnits(logicalTitleHeight);
+            
             this.MouseWheel += FenceWindow_MouseWheel;
             thumbnailProvider.IconThumbnailLoaded += ThumbnailProvider_IconThumbnailLoaded;
-            if (titleHeight < 16 || titleHeight > 100)
-                titleHeight = 35;
 
             ReloadFonts();
 
@@ -74,8 +75,8 @@ namespace NoFences
             Text = fenceInfo.Name;
             Location = new Point(fenceInfo.PosX, fenceInfo.PosY);
 
-            Width = fenceInfo.Width;
-            Height = fenceInfo.Height;
+            Width = LogicalToDeviceUnits(fenceInfo.Width);
+            Height = LogicalToDeviceUnits(fenceInfo.Height);
 
             prevHeight = Height;
             lockedToolStripMenuItem.Checked = fenceInfo.Locked;

--- a/NoFences/FenceWindow.cs
+++ b/NoFences/FenceWindow.cs
@@ -60,7 +60,7 @@ namespace NoFences
             WindowUtil.HideFromAltTab(Handle);
             DesktopUtil.GlueToDesktop(Handle);
             //DesktopUtil.PreventMinimize(Handle);
-            logicalTitleHeight = (fenceInfo.LogicalTitleHeight < 16 || fenceInfo.LogicalTitleHeight > 100) ? 35 : fenceInfo.LogicalTitleHeight;
+            logicalTitleHeight = (fenceInfo.TitleHeight < 16 || fenceInfo.TitleHeight > 100) ? 35 : fenceInfo.TitleHeight;
             titleHeight = LogicalToDeviceUnits(logicalTitleHeight);
             
             this.MouseWheel += FenceWindow_MouseWheel;
@@ -441,10 +441,10 @@ namespace NoFences
 
         private void titleSizeToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var dialog = new HeightDialog(fenceInfo.LogicalTitleHeight);
+            var dialog = new HeightDialog(fenceInfo.TitleHeight);
             if (dialog.ShowDialog(this) == DialogResult.OK)
             {
-                fenceInfo.LogicalTitleHeight = dialog.TitleHeight;
+                fenceInfo.TitleHeight = dialog.TitleHeight;
                 logicalTitleHeight = dialog.TitleHeight;
                 titleHeight = LogicalToDeviceUnits(logicalTitleHeight);
                 ReloadFonts();

--- a/NoFences/FenceWindow.cs
+++ b/NoFences/FenceWindow.cs
@@ -60,7 +60,7 @@ namespace NoFences
             WindowUtil.HideFromAltTab(Handle);
             DesktopUtil.GlueToDesktop(Handle);
             //DesktopUtil.PreventMinimize(Handle);
-            logicalTitleHeight = (fenceInfo.TitleHeight < 16 || fenceInfo.TitleHeight > 100) ? 35 : fenceInfo.TitleHeight;
+            logicalTitleHeight = (fenceInfo.LogicalTitleHeight < 16 || fenceInfo.LogicalTitleHeight > 100) ? 35 : fenceInfo.LogicalTitleHeight;
             titleHeight = LogicalToDeviceUnits(logicalTitleHeight);
             
             this.MouseWheel += FenceWindow_MouseWheel;
@@ -75,8 +75,8 @@ namespace NoFences
             Text = fenceInfo.Name;
             Location = new Point(fenceInfo.PosX, fenceInfo.PosY);
 
-            Width = LogicalToDeviceUnits(fenceInfo.Width);
-            Height = LogicalToDeviceUnits(fenceInfo.Height);
+            Width = fenceInfo.Width;
+            Height = fenceInfo.Height;
 
             prevHeight = Height;
             lockedToolStripMenuItem.Checked = fenceInfo.Locked;
@@ -441,10 +441,10 @@ namespace NoFences
 
         private void titleSizeToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var dialog = new HeightDialog(fenceInfo.TitleHeight);
+            var dialog = new HeightDialog(fenceInfo.LogicalTitleHeight);
             if (dialog.ShowDialog(this) == DialogResult.OK)
             {
-                fenceInfo.TitleHeight = dialog.TitleHeight;
+                fenceInfo.LogicalTitleHeight = dialog.TitleHeight;
                 logicalTitleHeight = dialog.TitleHeight;
                 titleHeight = LogicalToDeviceUnits(logicalTitleHeight);
                 ReloadFonts();

--- a/NoFences/FenceWindow.cs
+++ b/NoFences/FenceWindow.cs
@@ -445,7 +445,8 @@ namespace NoFences
             if (dialog.ShowDialog(this) == DialogResult.OK)
             {
                 fenceInfo.TitleHeight = dialog.TitleHeight;
-                titleHeight = dialog.TitleHeight;
+                logicalTitleHeight = dialog.TitleHeight;
+                titleHeight = LogicalToDeviceUnits(logicalTitleHeight);
                 ReloadFonts();
                 Minify();
                 if (isMinified)

--- a/NoFences/Model/FenceInfo.cs
+++ b/NoFences/Model/FenceInfo.cs
@@ -13,15 +13,24 @@ namespace NoFences.Model
 
         public int PosY { get; set; }
 
+        /// <summary>
+        /// Gets or sets the DPI scaled window width.
+        /// </summary>
         public int Width { get; set; }
 
+        /// <summary>
+        /// Gets or sets the DPI scaled window height.
+        /// </summary>
         public int Height { get; set; }
 
         public bool Locked { get; set; }
 
         public bool CanMinify { get; set; }
 
-        public int TitleHeight { get; set; } = 35;
+        /// <summary>
+        /// Gets or sets the logical window title height.
+        /// </summary>
+        public int LogicalTitleHeight { get; set; } = 35;
 
         public List<string> Files { get; set; } = new List<string>();
 

--- a/NoFences/Model/FenceInfo.cs
+++ b/NoFences/Model/FenceInfo.cs
@@ -5,6 +5,10 @@ namespace NoFences.Model
 {
     public class FenceInfo
     {
+        /* 
+         * DO NOT RENAME PROPERTIES. Used for XML serialization.
+         */
+
         public Guid Id { get; set; }
 
         public string Name { get; set; }
@@ -30,7 +34,7 @@ namespace NoFences.Model
         /// <summary>
         /// Gets or sets the logical window title height.
         /// </summary>
-        public int LogicalTitleHeight { get; set; } = 35;
+        public int TitleHeight { get; set; } = 35;
 
         public List<string> Files { get; set; } = new List<string>();
 

--- a/NoFences/NoFences.csproj
+++ b/NoFences/NoFences.csproj
@@ -32,6 +32,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -97,6 +100,7 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <None Include="app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/NoFences/app.manifest
+++ b/NoFences/app.manifest
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. 
+       
+       Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
+  <!--
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+  -->
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>


### PR DESCRIPTION
This pull request adds high DPI support (resolves #23).

![image](https://user-images.githubusercontent.com/36048059/168990621-874ab515-69f1-4846-a730-334b557b0bcc.png)

PerMonitorV2 (left) and DpiUnaware (right). Fonts and icons are scaled automatically. Custom render code has been adjusted to make sizes consistent across DPI settings.

Moving fences between monitors with different DPI settings might not work perfectly but I would expect users to leave their fences mostly on one screen.