### PR TITLE
Add drag and drop reordering feature

### DIFF
--- a/NoFences/FenceWindow.Designer.cs
+++ b/NoFences/FenceWindow.Designer.cs
@@ -128,9 +128,11 @@
             this.Paint += new System.Windows.Forms.PaintEventHandler(this.FenceWindow_Paint);
             this.DoubleClick += new System.EventHandler(this.FenceWindow_DoubleClick);
             this.MouseClick += new System.Windows.Forms.MouseEventHandler(this.FenceWindow_MouseClick);
+            this.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FenceWindow_Down);
             this.MouseEnter += new System.EventHandler(this.FenceWindow_MouseEnter);
             this.MouseLeave += new System.EventHandler(this.FenceWindow_MouseLeave);
             this.MouseMove += new System.Windows.Forms.MouseEventHandler(this.FenceWindow_MouseMove);
+            this.MouseUp += new System.Windows.Forms.MouseEventHandler(this.FenceWindow_Up);
             this.Resize += new System.EventHandler(this.FenceWindow_Resize);
             this.appContextMenu.ResumeLayout(false);
             this.ResumeLayout(false);

--- a/NoFences/Util/Extensions.cs
+++ b/NoFences/Util/Extensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
 
 namespace NoFences.Util
 {
@@ -14,6 +15,11 @@ namespace NoFences.Util
         public static Rectangle Shrink(this Rectangle rect, int offset)
         {
             return new Rectangle(rect.X + offset, rect.Y + offset, rect.Width - offset * 2, rect.Height - offset * 2);
+        }
+
+        public static double Distance(this Point p1, Point p2)
+        {
+            return Math.Round(Math.Sqrt(Math.Pow((p2.X - p1.X), 2) + Math.Pow((p2.Y - p1.Y), 2)), 1);
         }
 
     }


### PR DESCRIPTION
Added feature:
- drag and drop icons inside a fence to rearrange them (fence locking disables the feature),
fixes https://github.com/Twometer/NoFences/issues/26