### PR TITLE
Use the correct working directory when running a file

### DIFF
--- a/NoFences/Model/FenceEntry.cs
+++ b/NoFences/Model/FenceEntry.cs
@@ -58,7 +58,6 @@ namespace NoFences.Model
 					psi.WorkingDirectory = System.IO.Path.GetDirectoryName(Path);
 					if (Type == EntryType.Folder)
                     {
-                        psi.WorkingDirectory = Path;
                         psi.Arguments = Path;
 						psi.FileName = "explorer.exe";
 					}

--- a/NoFences/Model/FenceEntry.cs
+++ b/NoFences/Model/FenceEntry.cs
@@ -53,10 +53,16 @@ namespace NoFences.Model
                 // start asynchronously
                 try
                 {
-                    if (Type == EntryType.File)
-                        Process.Start(Path);
-                    else if (Type == EntryType.Folder)
-                        Process.Start("explorer.exe", Path);
+					ProcessStartInfo psi = new ProcessStartInfo();
+					psi.FileName = Path;
+					psi.WorkingDirectory = System.IO.Path.GetDirectoryName(Path);
+					if (Type == EntryType.Folder)
+                    {
+                        psi.WorkingDirectory = Path;
+                        psi.Arguments = Path;
+						psi.FileName = "explorer.exe";
+					}
+					Process.Start(psi);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Had a couple of bat files that used an ssh key located in the same folder; `Open()` was using the NoFences.exe directory as the working directory, so the ssh key wasn't found.